### PR TITLE
Retrieve sessionId from queryString

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ return new RedirectResponse($parser->urlFor('room', ['name' => 'session']));
 ### Start an [Archive](https://tokbox.com/developer/guides/archiving/)
 
 A `POST` request to the `/archive/start` route starts an archive recording of an OpenTok session.
-The session ID OpenTok session is passed in as JSON data in the body of the request
+The session ID OpenTok session is passed as POST variable (or JSON data in the body) of the request:
 
 ```php
 // Start Archiving and return the Archive

--- a/src/Action/Archive/StartAction.php
+++ b/src/Action/Archive/StartAction.php
@@ -22,8 +22,13 @@ class StartAction
 
     public function __invoke(ServerRequestInterface $request) : ResponseInterface
     {
-        $data = json_decode($request->getBody()->getContents(), true);
-        $sessionId = $data['sessionId'];
+        if(isset($_POST['sessionId'])) {
+            $sessionId = $_POST['sessionId'];
+        } else {
+            $data = json_decode($request->getBody()->getContents(), true);
+            $sessionId = $data['sessionId'];
+        }
+        
         $archive = $this->opentok->startArchive($sessionId, ['name' => 'Getting Started Sample Archive']);
 
         return new JsonResponse($archive->toJson());


### PR DESCRIPTION
Sending JSON looks like overkill, but we could just keep it as fallback for a value (other projects may be already using this server). 
Let's take `sessionId` from POST variable and if it does not exist take it from JSON body (like before)